### PR TITLE
Game-FPS-Lock

### DIFF
--- a/DisplayGraphics.java
+++ b/DisplayGraphics.java
@@ -9,6 +9,7 @@ import javax.swing.*;
  */
 public class DisplayGraphics extends JPanel implements KeyListener {
 
+    private static final int FRAMES_PER_SECOND = 120;
     public static Rectangle windowDimensions;
     private Player player = new Player();
     private ProjectilesArrayList playerProjectiles = new ProjectilesArrayList();
@@ -28,7 +29,7 @@ public class DisplayGraphics extends JPanel implements KeyListener {
     int playerShotDelayCounter = player.playerShotDelay;
     float soundtrackVolume = -15.0f;
     JFrame gameWindow = new JFrame();
-    Timer timer = new Timer(5, new TimerListener());
+    Timer timer = new Timer(1000 / FRAMES_PER_SECOND, new TimerListener());
 
     /**
      * Constructor method to initialize a timer and set the DisplayGraphics object
@@ -192,7 +193,6 @@ public class DisplayGraphics extends JPanel implements KeyListener {
 
                 int playerDamage = enemies.updateEnemies(playerProjectiles, playerWallet,
                         player.playerX, player.playerY, player.playerWidth, player.playerHeight);
-
 
                 for (int i = 0; i < playerDamage; i++) {
                     playerLoseHealth();

--- a/DisplayGraphics.java
+++ b/DisplayGraphics.java
@@ -49,9 +49,10 @@ public class DisplayGraphics extends JPanel implements KeyListener {
     }
 
     /**
-     * .
+     * Iterates across the enemiesArrayList and checks if any of their projectiles
+     * hit the player.
      * 
-     * @param enemiesArrayList .
+     * @param enemiesArrayList array list containing all of the enemies in the game
      */
     public void checkEnemyProjectiles(EnemiesArrayList enemiesArrayList) {
         ArrayList<Enemy> enemies = enemiesArrayList.enemies;
@@ -64,6 +65,10 @@ public class DisplayGraphics extends JPanel implements KeyListener {
         }
     }
 
+    /**
+     * Lowers the players health and plays a sound when run, additionally it checks
+     * if the player's health goes to 0 and if it does then it ends the game.
+     */
     public void playerLoseHealth() {
         sound.setSoundEffect(2);
         sound.play();


### PR DESCRIPTION
Converted the game loop from running on the default swing Timer as it meant that the code would run faster on faster hardware and did not allow granular control over the game updates per second and the frames per second. Added a method to start the game loop that updates the screen and game at different intervals. 

Updating the screen and game state seperately allows for weaker hardware to run the game can be fluidly while not using too many system resources to draw to the screen unnecessary.

Added a new method that uses the current time in nanoseconds gotten from the computer to determine after how much time the game should be updated. Then using predetermined UPS and FPS rates it updates the game and screen every time difference that would be equal to or above the time between updates.

This requires no further implementation and the topic can be considered closed.